### PR TITLE
workflow: remove clang

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         build_type: [Release]
-        c_compiler: [gcc, clang, cl]
+        c_compiler: [gcc, cl]
         include:
           - os: windows-latest
             c_compiler: cl
@@ -33,14 +33,9 @@ jobs:
           - os: ubuntu-latest
             c_compiler: gcc
             cpp_compiler: g++
-          - os: ubuntu-latest
-            c_compiler: clang
-            cpp_compiler: clang++
         exclude:
           - os: windows-latest
             c_compiler: gcc
-          - os: windows-latest
-            c_compiler: clang
           - os: ubuntu-latest
             c_compiler: cl
 


### PR DESCRIPTION
Currently ubuntu-latest (jammy) uses clang15 which requires typename before dependent types. This patch can be reverted when ubuntu-latest uses clang16 or later.

References:

https://stackoverflow.com/questions/76426782/clang-fails-to-compile-with-boostrational Cppreference says that "Make typename more optional" from C++20 was implemented in Clang 16, and libstdc++ 13 seems to rely on it.